### PR TITLE
feature(html-download): support the loading of some iframes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ This project is very fresh (rolled on 6 May 2025). I may yet publish to npm or c
 - 📑 Page selector and navigation controls
 - 🔍 Basic search within PDFs
 - ⬇️ Download PDF button
+- 🌐 Smart handling of HTML-wrapped PDF downloads
 - 🛠️ Based on [pdf.js](https://github.com/mozilla/pdf.js)
 
 ## Usage and features
@@ -68,19 +69,48 @@ Set options via data attributes on the container:
   - **Note:** Disabling WebGL (the default) seems to be more performant in most browsers.
 - `data-momentum` (number): Controls the speed of grab-and-scroll (momentum) for fast navigation. Default is 1. Higher values allow faster scrolling when dragging the document horizontally.
 
+## HTML Download Handler
+
+Note this is an advanced feature and may require some customisation or adaptation.
+
+PDF-A-go-go includes smart handling for cases where a PDF URL initially returns an HTML page that triggers the actual PDF download. This is common with institutional repositories, document management systems, and academic websites.
+
+When such a case is detected, PDF-A-go-go will:
+
+1. Display the HTML page in an iframe
+2. Monitor for PDF download links or triggers
+3. Automatically handle the PDF download once detected
+4. Display the PDF in the viewer
+
+To configure the HTML download handler behavior, use these options:
+
+```html
+<div class="pdfagogo-container"
+     data-pdf-url="https://example.com/document/download"
+     data-download-timeout="30000"
+     ...></div>
+```
+
+Options:
+
+- `data-download-timeout` (number): Time in milliseconds to wait for PDF download to start (default: 30000)
+
+You can see this in action in the [HTML download example](html-download-example.html).
+
 
 ## Performance Monitoring
 
 PDF-A-go-go includes a debug mode that provides detailed performance metrics for PDF loading and rendering. To enable debug mode, add the `data-debug="true"` attribute to your container:
 
 ```html
-<div class="pdfagogo-container" 
+<div class="pdfagogo-container"
      data-pdf-url="./example.pdf"
      data-debug="true"
      ...></div>
 ```
 
 When debug mode is enabled, the following metrics are logged to the console:
+
 - Initial render time for all pages
 - Individual page render times (both low and high resolution)
 - Average render times for low and high resolution pages
@@ -95,6 +125,7 @@ console.log(metrics);
 ```
 
 The metrics object includes:
+
 - `initialRenderTime`: Time taken for initial render of all pages (ms)
 - `averageLowResRenderTime`: Average time to render a page in low resolution (ms)
 - `averageHighResRenderTime`: Average time to upgrade a page to high resolution (ms)
@@ -116,6 +147,7 @@ To set up a local development environment:
 ## Testing
 
 PDF-A-go-go includes automated performance tests using Playwright. These tests measure:
+
 - Initial render time
 - Low and high resolution render times
 - CPU usage
@@ -135,6 +167,7 @@ npm run test:debug
 ```
 
 The test suite includes:
+
 - Desktop performance testing with standard viewport (1280x800)
 - Mobile performance testing with:
   - Reduced viewport (375x667)
@@ -142,6 +175,7 @@ The test suite includes:
   - Extended timeouts for mobile conditions
 
 Performance thresholds are set to:
+
 - Desktop: Initial render < 5s, Average CPU < 80%
 - Mobile: Initial render < 10s, Average CPU < 90%
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Set options via data attributes on the container:
   - **Note:** Disabling WebGL (the default) seems to be more performant in most browsers.
 - `data-momentum` (number): Controls the speed of grab-and-scroll (momentum) for fast navigation. Default is 1. Higher values allow faster scrolling when dragging the document horizontally.
 
+
 ## Performance Monitoring
 
 PDF-A-go-go includes a debug mode that provides detailed performance metrics for PDF loading and rendering. To enable debug mode, add the `data-debug="true"` attribute to your container:

--- a/README.md
+++ b/README.md
@@ -71,7 +71,11 @@ Set options via data attributes on the container:
 
 ## HTML Download Handler
 
-Note this is an advanced feature and may require some customisation or adaptation.
+---
+
+Note this is an advanced feature and may require some customisation or adaptation. It is quite experimental. See more in https://github.com/khawkins98/PDF-A-go-go/pull/7
+
+---
 
 PDF-A-go-go includes smart handling for cases where a PDF URL initially returns an HTML page that triggers the actual PDF download. This is common with institutional repositories, document management systems, and academic websites.
 

--- a/src/html-download-example-iframe.html
+++ b/src/html-download-example-iframe.html
@@ -1,0 +1,96 @@
+<!-- This is an example the HTML page that is returned by example iframe handler -->
+<!-- We do this hear to avoid CORS complexities, you should ensue your content material is on the same domain or has appropriate cors -->
+<!DOCTYPE html>
+<html
+  lang="en"
+  dir="ltr"
+  prefix="content: http://purl.org/rss/1.0/modules/content/  dc: http://purl.org/dc/terms/  foaf: http://xmlns.com/foaf/0.1/  og: http://ogp.me/ns#  rdfs: http://www.w3.org/2000/01/rdf-schema#  schema: http://schema.org/  sioc: http://rdfs.org/sioc/ns#  sioct: http://rdfs.org/sioc/types#  skos: http://www.w3.org/2004/02/skos/core#  xsd: http://www.w3.org/2001/XMLSchema# "
+>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="vf:page-type" content="category;download" />
+    <title>
+      [file] GAR Special Report 2024: Forensic Insights for Future Resilience - Learning from Past Disasters (100220)
+    </title>
+    <meta http-equiv="refresh" content="3; url=example_spread.pdf" />
+    <!-- <meta http-equiv="refresh" content="3; url=https://www.undrr.org/media/100220/download?startDownload=20250516" /> -->
+  </head>
+  <body>
+    <style type="text/css">
+      @import url("https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@200&amp;amp;family=Roboto:wght@400;700&amp;amp;display=swap");
+      body {
+        font-family: "Roboto", sans-serif;
+        background: #dde8f0;
+        margin: 0;
+      }
+      .undrr-interstitial--inner-content {
+        background: #fff;
+        padding: 2rem 1.5rem 1rem;
+        max-width: 900px;
+        margin: 2rem auto;
+      }
+      h1 {
+        color: #004f91;
+        font-size: 0.9rem;
+        padding: 0;
+        margin: 0;
+      }
+      h2 {
+        padding-top: 0;
+        margin-top: 0.5rem;
+      }
+      code {
+        font-family: "Roboto Mono", monospace;
+      }
+      pre {
+        margin: 0;
+        padding: 0.5rem 1rem;
+        background: #eee;
+        display: inline-block;
+      }
+      hr {
+        border: 0;
+        border-top: 1px solid #ccc;
+        margin: 2rem 0 0.5rem;
+      }
+      .undrr-logo {
+        background: url(https://www.undrr.org/sites/default/files/2023-04/undrr-logo-blue.svg)
+          no-repeat left center;
+        max-width: 350px;
+        min-width: 200px;
+        min-height: 80px;
+      }
+    </style>
+    <article class="undrr-interstitial--inner-content">
+      <h1>Document download</h1>
+      <h2>Your download will begin automatically.</h2>
+      <p>
+        If the download does not begin,
+        <a class="download-direct-link" href="#" target="_blank"
+          >please click here to download directly</a
+        >.
+      </p>
+      <hr />
+      <p><small>This website is operated by</small></p>
+      <div class="undrr-logo">&nbsp;</div>
+    </article>
+    <script
+      type="text/javascript"
+      src="//www.undrr.org/modules/custom/undrr_custom/js/google_analytics_enhancements.js?update=20230418"
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"
+    ></script>
+    <script>
+      // set fallback download link
+      // https://drupal-testing.preventionweb.net/media/87206/download?startDownload=20250516
+      var mediaId = window.location.href.replace(/\/$/, "");
+      mediaId = mediaId.substr(mediaId.lastIndexOf("/") + 1);
+      var downloadLinkUrl =
+        "https://www.undrr.org/media/" +
+        mediaId +
+        "/download?startDownload=20250516";
+      var downloadLinkElement = document.querySelector(".download-direct-link");
+      downloadLinkElement.setAttribute("href", downloadLinkUrl);
+    </script>
+  </body>
+</html>

--- a/src/html-download-example.html
+++ b/src/html-download-example.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>PDF-A-go-go HTML Download Handler Example</title>
+  <link rel="stylesheet" href="pdf-a-go-go.css">
+  <style>
+    body {
+      margin: 0;
+      padding: 20px;
+      font-family: system-ui, -apple-system, sans-serif;
+    }
+    .container {
+      max-width: 1200px;
+      margin: 0 auto;
+    }
+    .viewer {
+      width: 100%;
+      height: 800px;
+      border: 1px solid #ddd;
+      margin: 20px 0;
+    }
+    .description {
+      margin: 20px 0;
+      padding: 20px;
+      background: #f5f5f5;
+      border-radius: 4px;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>PDF-A-go-go HTML Download Handler Example</h1>
+
+    <div class="description">
+      <h2>About this example</h2>
+      <p>This example demonstrates how PDF-A-go-go handles cases where a PDF download URL initially returns an HTML page that triggers the actual PDF download. This is common with institutional repositories and document management systems.</p>
+      <p>The viewer below is configured to load a URL that returns an HTML page first. The viewer will:</p>
+      <ol>
+        <li>Show the HTML page in an iframe</li>
+        <li>Wait for the PDF download to start</li>
+        <li>Load the PDF once downloaded</li>
+      </ol>
+    </div>
+
+    <div id="pdfagogo-container" class="pdfagogo-container"
+         tabindex="0"
+         role="region"
+         aria-label="PDF Viewer"
+         aria-live="polite"
+         aria-atomic="true"
+         data-pdf-url="html-download-example-iframe.html"
+         data-show-search="true"
+         data-show-prev-next="true"
+         data-show-page-selector="true"
+         data-show-current-page="true"
+         data-show-download="true"
+         data-debug="true"
+         data-download-timeout="60000"
+         style="width:100%;height:800px;border:1px solid #ddd;margin:20px 0;">
+    </div>
+  </div>
+
+  <script defer="defer" src="pdf-a-go-go.js"></script>
+</body>
+</html>

--- a/src/html-download-example.html
+++ b/src/html-download-example.html
@@ -44,7 +44,8 @@
       </ol>
     </div>
 
-    <div id="pdfagogo-container" class="pdfagogo-container"
+    <div id="pdfagogo-container"
+         class="pdfagogo-container"
          tabindex="0"
          role="region"
          aria-label="PDF Viewer"

--- a/src/htmlDownloadHandler.js
+++ b/src/htmlDownloadHandler.js
@@ -1,0 +1,257 @@
+/**
+ * HTMLDownloadHandler - Handles cases where a PDF download URL initially returns an HTML page
+ * that triggers the actual PDF download.
+ */
+export class HTMLDownloadHandler extends EventTarget {
+  constructor(options = {}) {
+    super();
+    this.options = options;
+    this.iframe = null;
+    this.container = null;
+    this.downloadTimeout = options.downloadTimeout || 30000; // 30 second timeout by default
+  }
+
+  /**
+   * Initialize the handler with a container element
+   * @param {HTMLElement} container - The container element to render the iframe in
+   */
+  initialize(container) {
+    this.container = container;
+    this.container.style.position = 'relative';
+  }
+
+  /**
+   * Handle a URL that returns HTML instead of a PDF
+   * @param {string} url - The URL that returned HTML
+   * @returns {Promise<Blob>} - Promise that resolves with the downloaded PDF blob
+   */
+  async handleHTMLDownload(url) {
+    return new Promise((resolve, reject) => {
+      // Create loading indicator
+      // const loadingDiv = document.createElement('div');
+      // loadingDiv.className = 'pdfagogo-html-loading';
+      // loadingDiv.innerHTML = `
+      //   <div class="pdfagogo-html-loading-content">
+      //     <div class="pdfagogo-html-loading-spinner"></div>
+      //     <div class="pdfagogo-html-loading-text">
+      //       Preparing document...
+      //     </div>
+      //   </div>
+      // `;
+      // this.container.appendChild(loadingDiv);
+
+      // Set up timeout
+      const downloadTimeout = setTimeout(() => {
+        this.cleanup();
+        reject(new Error('Download timeout - no redirect detected'));
+      }, this.downloadTimeout);
+
+      // Function to check a URL and download if it's a PDF
+      const checkUrlAndDownload = async (urlToCheck) => {
+        console.log('Checking URL:', urlToCheck);
+        try {
+          // Try a HEAD request first to check content type
+          const headResponse = await fetch(urlToCheck, {
+            method: 'HEAD',
+            credentials: 'include'
+          });
+          const contentType = headResponse.headers.get('content-type');
+          console.log('Content type:', contentType);
+
+          if (contentType && contentType.toLowerCase().includes('pdf')) {
+            clearTimeout(downloadTimeout);
+            this.downloadPDF(urlToCheck).then(resolve).catch(reject);
+            return true;
+          }
+        } catch (e) {
+          console.log('HEAD request failed, will try direct download:', e);
+        }
+        return false;
+      };
+
+      // Create a proxy iframe that will intercept redirects
+      const proxyFrame = document.createElement('iframe');
+      proxyFrame.style.display = 'none';
+      document.body.appendChild(proxyFrame);
+
+      // Write content to the proxy iframe that will help us detect redirects
+      const proxyContent = `
+        <!DOCTYPE html>
+        <html>
+        <head>
+          <script>
+            // Function to check if a string might be a PDF URL
+            function mightBePdfUrl(url) {
+              return url.toLowerCase().endsWith('.pdf') ||
+                     url.toLowerCase().includes('/pdf/') ||
+                     url.toLowerCase().includes('download') ||
+                     url.toLowerCase().includes('document');
+            }
+
+            // Function to parse meta refresh content for delay and URL using string split
+            function parseMetaRefresh(content) {
+              // Example: "5; url=http://example.com/file.pdf"
+              if (!content) return null;
+              const parts = content.split(';');
+              if (parts.length < 2) return null;
+
+              // First part: delay (seconds)
+              const delay = parseInt(parts[0].trim(), 10) || 0;
+
+              // Second part: url=...
+              const urlPart = parts.slice(1).join(';').trim(); // in case there are extra semicolons in the URL
+              const urlMatch = urlPart.match(/url\s*=\s*['"]?([^'"]+)['"]?/i);
+              if (!urlMatch) return null;
+
+              const url = urlMatch[1].trim();
+              return { delay, url };
+            }
+
+            // Function to check meta refresh tags
+            function checkMetaRefresh() {
+              const frame = document.getElementById('contentFrame');
+              if (!frame || !frame.contentDocument) return;
+
+              const metaTags = frame.contentDocument.getElementsByTagName('meta');
+              for (const meta of metaTags) {
+                if (meta.httpEquiv && meta.httpEquiv.toLowerCase() === 'refresh') {
+                  const result = parseMetaRefresh(meta.content);
+                  console.log('metaRefresh', result, meta);
+                  if (result && result.url) {
+                    // Convert relative URL to absolute
+                    const link = document.createElement('a');
+                    link.href = result.url;
+
+                    // Remove the meta refresh tag to prevent native redirect
+                    meta.parentNode.removeChild(meta);
+
+                    // Respect the delay before posting the message
+                    setTimeout(() => {
+                      window.parent.postMessage({
+                        type: 'potentialPdfUrl',
+                        url: link.href,
+                        source: 'metaRefresh'
+                      }, '*');
+                    }, result.delay * 1000); // delay is in seconds
+                  }
+                }
+              }
+            }
+
+            // Set up message handler
+            window.addEventListener('message', function(event) {
+              if (event.data.type === 'checkUrl') {
+                var link = document.createElement('a');
+                link.href = event.data.url;
+
+                // If it might be a PDF URL, send it back to parent
+                if (mightBePdfUrl(link.href)) {
+                  window.parent.postMessage({
+                    type: 'potentialPdfUrl',
+                    url: link.href
+                  }, '*');
+                }
+
+                // Get the content frame and set up load handler
+                const frame = document.getElementById('contentFrame');
+                if (frame) {
+                  frame.onload = checkMetaRefresh;
+                  frame.src = event.data.url;
+                }
+              }
+            });
+
+            // Intercept all link clicks
+            document.addEventListener('click', function(e) {
+              if (e.target.tagName === 'A') {
+                e.preventDefault();
+                window.parent.postMessage({
+                  type: 'potentialPdfUrl',
+                  url: e.target.href
+                }, '*');
+              }
+            }, true);
+          </script>
+        </head>
+        <body>
+          <iframe id="contentFrame" style="width:100%;height:100%;border:none;"></iframe>
+        </body>
+        </html>
+      `;
+      proxyFrame.contentDocument.write(proxyContent);
+      proxyFrame.contentDocument.close();
+
+      // Listen for messages from the proxy iframe
+      const messageHandler = async (event) => {
+        if (event.data.type === 'potentialPdfUrl') {
+            console.log('potentialPdfUrl', event.data.url, event.data.source);
+          const isPdf = await checkUrlAndDownload(event.data.url);
+          if (isPdf) {
+            window.removeEventListener('message', messageHandler);
+            proxyFrame.remove();
+          }
+        }
+      };
+      window.addEventListener('message', messageHandler);
+
+      // Create the main iframe
+      this.iframe = document.createElement('iframe');
+      this.iframe.className = 'pdfagogo-html-iframe';
+      this.iframe.src = url;
+
+      // When the main iframe loads, have the proxy check its URL
+      this.iframe.onload = () => {
+        try {
+          proxyFrame.contentWindow.postMessage({
+            type: 'checkUrl',
+            url: this.iframe.src
+          }, '*');
+        } catch (e) {
+          console.log('Error checking iframe URL:', e);
+        }
+      };
+
+      this.container.appendChild(this.iframe);
+    });
+  }
+
+  /**
+   * Download a PDF from a URL
+   * @param {string} url - The PDF URL to download
+   * @returns {Promise<Blob>} - Promise that resolves with the PDF blob
+   */
+  async downloadPDF(url) {
+    console.log('Downloading PDF from', url);
+    try {
+      const response = await fetch(url, {
+        credentials: 'include' // Include cookies for authenticated downloads
+      });
+      if (!response.ok) throw new Error('PDF download failed: ' + response.statusText);
+
+      const blob = await response.blob();
+      console.log('Downloaded blob', blob);
+      if (!blob.type.includes('pdf')) {
+        throw new Error(`Downloaded file is not a PDF (type: ${blob.type})`);
+      }
+
+      this.cleanup();
+      return blob;
+    } catch (error) {
+      this.cleanup();
+      throw error;
+    }
+  }
+
+  /**
+   * Clean up the handler's DOM elements
+   */
+  cleanup() {
+    if (this.iframe && this.iframe.parentNode) {
+      this.iframe.parentNode.removeChild(this.iframe);
+    }
+    const loadingDiv = this.container.querySelector('.pdfagogo-html-loading');
+    if (loadingDiv && loadingDiv.parentNode) {
+      loadingDiv.parentNode.removeChild(loadingDiv);
+    }
+  }
+}

--- a/src/pdf-a-go-go.css
+++ b/src/pdf-a-go-go.css
@@ -356,3 +356,59 @@
 .pdfagogo-debug-info .memory {
   color: #ff9900;
 }
+
+/* HTML Download Handler styles */
+.pdfagogo-html-iframe {
+  width: 100%;
+  height: 100%;
+  border: none;
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 1;
+}
+
+.pdfagogo-html-loading {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  background: rgba(255, 255, 255, 0.9);
+  padding: 20px;
+  z-index: 2;
+  border-bottom: 1px solid #ddd;
+}
+
+.pdfagogo-html-loading-content {
+  display: flex;
+  align-items: center;
+  gap: 15px;
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.pdfagogo-html-loading-spinner {
+  width: 24px;
+  height: 24px;
+  border: 3px solid #f3f3f3;
+  border-top: 3px solid #3498db;
+  border-radius: 50%;
+  animation: pdfagogo-spin 1s linear infinite;
+}
+
+.pdfagogo-html-loading-text {
+  flex: 1;
+  font-size: 16px;
+  color: #333;
+}
+
+.pdfagogo-html-loading-subtext {
+  font-size: 14px;
+  color: #666;
+  margin-top: 5px;
+}
+
+@keyframes pdfagogo-spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}

--- a/src/pdfLoader.js
+++ b/src/pdfLoader.js
@@ -2,23 +2,75 @@
  * Loads a PDF using PDF.js and provides progress updates.
  * @param {string} url - The URL of the PDF to load.
  * @param {(progress: number|null) => void} onProgress - Callback for progress updates (0-1 or null for indeterminate).
+ * @param {Object} options - Additional options for loading
+ * @param {HTMLElement} options.container - Container element for HTML download handling
+ * @param {number} options.downloadTimeout - Timeout for HTML download handling
  * @returns {Promise<Object>} Resolves with the loaded PDF document.
  */
 import * as pdfjsLib from "pdfjs-dist/build/pdf.mjs";
 import pdfWorkerUrl from "pdfjs-dist/build/pdf.worker.min.mjs";
+import { HTMLDownloadHandler } from "./htmlDownloadHandler.js";
 
 pdfjsLib.GlobalWorkerOptions.workerSrc = pdfWorkerUrl;
 
-export function loadPdfWithProgress(url, onProgress) {
-  const loadingTask = pdfjsLib.getDocument(url);
-  if (onProgress && loadingTask && loadingTask.onProgress !== undefined) {
-    loadingTask.onProgress = function (progressData) {
-      if (progressData && progressData.loaded && progressData.total) {
-        onProgress(progressData.loaded / progressData.total);
-      } else {
-        onProgress(null); // Indeterminate
+export async function loadPdfWithProgress(url, onProgress, options = {}) {
+  try {
+    // First try to fetch the URL to check its content type
+    const response = await fetch(url);
+    const contentType = response.headers.get('content-type');
+
+    // If it's HTML content, handle it with HTMLDownloadHandler
+    if (contentType && contentType.includes('text/html')) {
+      if (!options.container) {
+        throw new Error('Container element is required for HTML download handling');
       }
-    };
+
+      const handler = new HTMLDownloadHandler({
+        downloadTimeout: options.downloadTimeout
+      });
+      handler.initialize(options.container);
+
+      // Get the PDF blob from the handler
+      const pdfBlob = await handler.handleHTMLDownload(url);
+      
+      // Create a URL from the blob
+      const pdfUrl = URL.createObjectURL(pdfBlob);
+
+      // Load the PDF with PDF.js
+      const loadingTask = pdfjsLib.getDocument(pdfUrl);
+      if (onProgress && loadingTask.onProgress !== undefined) {
+        loadingTask.onProgress = function (progressData) {
+          if (progressData && progressData.loaded && progressData.total) {
+            onProgress(progressData.loaded / progressData.total);
+          } else {
+            onProgress(null); // Indeterminate
+          }
+        };
+      }
+
+      try {
+        const pdf = await loadingTask.promise;
+        return pdf;
+      } finally {
+        // Clean up the blob URL
+        URL.revokeObjectURL(pdfUrl);
+      }
+    }
+
+    // If it's a PDF or other content, load directly with PDF.js
+    const loadingTask = pdfjsLib.getDocument(url);
+    if (onProgress && loadingTask.onProgress !== undefined) {
+      loadingTask.onProgress = function (progressData) {
+        if (progressData && progressData.loaded && progressData.total) {
+          onProgress(progressData.loaded / progressData.total);
+        } else {
+          onProgress(null); // Indeterminate
+        }
+      };
+    }
+    return loadingTask.promise;
+  } catch (error) {
+    console.error('Error loading PDF:', error);
+    throw error;
   }
-  return loadingTask.promise;
 } 

--- a/src/pdfagogo.js
+++ b/src/pdfagogo.js
@@ -121,9 +121,16 @@ function init(book, id, opts, cb) {
   }
 
   // Load PDF with progress
-  loadPdfWithProgress(featureOptions.pdfUrl, (progress) => {
-    updateLoadingBar(progressBar, progress);
-  })
+  loadPdfWithProgress(
+    featureOptions.pdfUrl, 
+    (progress) => {
+      updateLoadingBar(progressBar, progress);
+    },
+    {
+      container: pdfagogoContainer,
+      downloadTimeout: parseInt(pdfagogoContainer.dataset.downloadTimeout, 10) || 30000
+    }
+  )
     .then(async function (loadedPdf) {
       pdf = loadedPdf;
       const book = {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,6 +36,8 @@ const base = {
         { from: 'src/pdf-a-go-go.css', to: 'pdf-a-go-go.css' },
         { from: 'src/index.html', to: 'index.html' },
         { from: 'src/double-spread.html', to: 'double-spread.html' },
+        { from: 'src/html-download-example.html', to: 'html-download-example.html' },
+        { from: 'src/html-download-example-iframe.html', to: 'html-download-example-iframe.html' },
         { from: 'src/example.pdf', to: 'example.pdf' },
         { from: 'src/example_spread.pdf', to: 'example_spread.pdf' },
         { from: 'src/tests', to: 'tests' }


### PR DESCRIPTION
This PR enables support of loading PDFs through some types of iframe intersessiels, those that use <meta http-equiv="refresh"> to trigger PDF downloads. The main changes are:

-  parseMetaRefresh uses a string split approach to reliably extract the delay and URL from the meta tag's content, supporting a wider range of real-world formats (including optional quotes and semicolons in URLs).
Respect for delay:
- a handler waits for the specified delay (in seconds) before proceeding with the redirect, matching browser behavior.
-  After detecting and processing a meta refresh, the corresponding meta tag is removed from the document to prevent the browser from performing a native redirect, ensuring that only the handler logic manages the redirect.

This is quite experimental