### PR TITLE
feature: Redesign toolbar with modern icons and improved page navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,12 @@ Performance thresholds (as enforced by tests):
 
 The development server runs on port 9000 by default (<http://localhost:9000>).
 
+## Credits
+
+- **[PDF.js](https://github.com/mozilla/pdf.js)** - Mozilla's PDF rendering library (Apache 2.0 License)
+- **[Lucide](https://lucide.dev)** - Beautiful open-source icons (MIT License)
+- **[embed-pdf-viewer](https://github.com/embedpdf/embed-pdf-viewer)** - UI design inspiration
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/src/assets/css/pdf-a-go-go.css
+++ b/src/assets/css/pdf-a-go-go.css
@@ -1,3 +1,8 @@
+/**
+ * PDF-A-go-go Styles
+ * Icons: Lucide (https://lucide.dev) - MIT License
+ */
+
 .pdfagogo-viewer-wrapper {
   display: grid;
   gap: 1rem;
@@ -6,10 +11,11 @@
   width: 100%;
   height: 80vh;
   border: 1px solid #ccc;
-  padding: 1rem 0;
-  background: #353535;
+  padding: 0;
+  background: #e4e4e4;
   text-align: center;
   position: relative;
+  overflow: hidden;
 }
 /* Wrapper to group controls + viewer for fullscreen */
 .pdfagogo-viewer-wrapper:fullscreen {
@@ -30,46 +36,279 @@
   outline: 3px solid #1976d2;
   outline-offset: 2px;
 }
-.pdfagogo-controls {
-  max-width: 1200px;
-  margin: 0 auto 20px auto;
-  text-align: center;
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: center;
-  gap: 8px 12px;
+/* Page input invalid state */
+.pdfagogo-goto-page.invalid {
+  animation: pdfagogo-shake 0.3s ease;
+  border-color: #d32f2f;
+  background: #ffebee;
 }
+@keyframes pdfagogo-shake {
+  0%, 100% { transform: translateX(0); }
+  25% { transform: translateX(-4px); }
+  75% { transform: translateX(4px); }
+}
+/* Accessibility instructions - collapsible */
 .pdfagogo-a11y-instructions {
   max-width: 1200px;
   margin: 0 auto 20px auto;
-  font-size: 1rem;
-  color: #333;
+  font-size: 0.9rem;
+  color: #555;
   background: #f5f5f5;
-  padding: 10px;
+  padding: 8px 12px;
   border-radius: 6px;
 }
-.pdfagogo-search-controls {
-  max-width: 1200px;
-  margin: 0 auto 10px auto;
+.pdfagogo-a11y-instructions summary {
+  cursor: pointer;
+  font-weight: 500;
+  color: #333;
+}
+.pdfagogo-a11y-instructions ul {
+  margin: 8px 0 0 0;
+  padding-left: 20px;
+}
+.pdfagogo-a11y-instructions li {
+  margin: 4px 0;
+}
+.pdfagogo-a11y-instructions kbd {
+  background: #e0e0e0;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  padding: 1px 5px;
+  font-family: inherit;
+  font-size: 0.85em;
+}
+/* Top toolbar */
+.pdfagogo-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 12px;
+  background: #fff;
+  border-bottom: 1px solid #ddd;
+  font-size: 14px;
+  position: relative;
+  z-index: 10;
+  min-height: 44px;
+  box-sizing: border-box;
+}
+.pdfagogo-toolbar-section {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  height: 28px;
+}
+.pdfagogo-toolbar-left {
+  flex: 0 0 auto;
+}
+.pdfagogo-toolbar-center {
+  flex: 1 1 auto;
+  justify-content: center;
+}
+.pdfagogo-toolbar-right {
+  flex: 0 0 auto;
+}
+/* Toolbar buttons */
+.pdfagogo-toolbar button {
+  background: none;
+  border: 1px solid transparent;
+  cursor: pointer;
+  padding: 6px 8px;
+  color: #555;
+  border-radius: 4px;
+  line-height: 1;
+  transition: background 0.15s, border-color 0.15s;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 28px;
+  box-sizing: border-box;
+  margin: 0
+}
+.pdfagogo-toolbar button svg {
+  display: block;
+  flex-shrink: 0;
+}
+.pdfagogo-toolbar button:hover {
+  background: #e8e8e8;
+  border-color: #ccc;
+  color: #333;
+}
+.pdfagogo-toolbar button.active {
+  background: #e0e0e0;
+  border-color: #bbb;
+}
+.pdfagogo-toolbar button.copied {
+  color: #4caf50;
+}
+.pdfagogo-toolbar button.disabled,
+.pdfagogo-toolbar button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.pdfagogo-toolbar button.disabled:hover,
+.pdfagogo-toolbar button:disabled:hover {
+  background: none;
+  border-color: transparent;
+}
+/* Page navigation group */
+.pdfagogo-page-nav {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  background: #fff;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  padding: 2px;
+  height: 32px;
+  box-sizing: border-box;
+}
+.pdfagogo-page-nav button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px 6px;
+  color: #555;
+  border-radius: 4px;
+  line-height: 1;
+  transition: background 0.15s;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 26px;
+  box-sizing: border-box;
+}
+.pdfagogo-page-nav button:hover:not(:disabled) {
+  background: #f0f0f0;
+}
+.pdfagogo-page-nav button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.pdfagogo-page-nav button:disabled:hover {
+  background: none;
+}
+/* Page input in toolbar */
+.pdfagogo-toolbar .pdfagogo-goto-page {
+  width: 36px;
+  padding: 2px 4px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 13px;
   text-align: center;
-}
-/* When search controls are placed inside the main controls, make them inline */
-.pdfagogo-controls .pdfagogo-search-controls {
-  display: contents;
-  max-width: none;
+  height: 26px;
+  box-sizing: border-box;
   margin: 0;
-  text-align: inherit;
+  background: #fff;
 }
-.pdfagogo-search-controls input {
-  padding: 6px 10px;
-  font-size: 16px;
-  width: 220px;
+.pdfagogo-toolbar .pdfagogo-goto-page:focus {
+  outline: 2px solid #1976d2;
+  outline-offset: 1px;
+  border-color: #1976d2;
 }
-.pdfagogo-search-result {
-  margin-left: 10px;
+/* Page total in toolbar */
+.pdfagogo-toolbar .pdfagogo-page-total {
+  font-size: 13px;
+  color: #555;
+  white-space: nowrap;
+  line-height: 26px;
+  padding: 0 4px;
+}
+.pdfagogo-toolbar .pdfagogo-page-total::before {
+  content: "/";
+  margin-right: 4px;
+  color: #999;
+}
+/* Zoom indicator in toolbar */
+.pdfagogo-toolbar .pdfagogo-zoom-indicator {
+  font-size: 12px;
   color: #1976d2;
-  font-size: 15px;
+  background: #e3f2fd;
+  padding: 0 6px;
+  border-radius: 4px;
+  white-space: nowrap;
+  height: 28px;
+  line-height: 28px;
+  box-sizing: border-box;
+}
+/* Search group in toolbar */
+.pdfagogo-search-group {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  background: #fff;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  padding: 2px 6px;
+  height: 28px;
+  box-sizing: border-box;
+}
+.pdfagogo-search-group .pdfagogo-search-input {
+  border: none;
+  outline: none;
+  padding: 4px 8px;
+  font-size: 13px;
+  width: 120px;
+  background: transparent;
+  height: 100%;
+  box-sizing: border-box;
+  margin: 0
+}
+.pdfagogo-search-group .pdfagogo-search-input::placeholder {
+  color: #999;
+}
+.pdfagogo-search-group .pdfagogo-search-result {
+  font-size: 12px;
+  color: #666;
+  padding: 0 4px;
+  white-space: nowrap;
+  line-height: 1;
+}
+.pdfagogo-search-group button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 2px 6px;
+  font-size: 12px;
+  color: #666;
+  border-radius: 3px;
+  height: 22px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+}
+.pdfagogo-search-group button:hover:not(:disabled) {
+  background: #f0f0f0;
+  color: #333;
+}
+.pdfagogo-search-group button:disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+/* Responsive toolbar */
+@media (max-width: 480px) {
+  .pdfagogo-toolbar {
+    flex-wrap: wrap;
+    padding: 6px 8px;
+    gap: 6px;
+    min-height: auto;
+  }
+  .pdfagogo-toolbar-section {
+    height: 28px;
+  }
+  .pdfagogo-toolbar-center {
+    order: 3;
+    flex: 1 0 100%;
+    justify-content: stretch;
+  }
+  .pdfagogo-search-group {
+    width: 100%;
+  }
+  .pdfagogo-search-group .pdfagogo-search-input {
+    flex: 1;
+    width: auto;
+  }
 }
 .pdfagogo-loading {
   position: absolute;
@@ -206,7 +445,7 @@
 }
 .pdfagogo-page-wrapper {
   margin: 1.5rem auto;
-  background: #222;
+  background: #fff;
   border-radius: 8px;
   box-shadow: 0 2px 12px rgba(0,0,0,0.18);
   transition: transform 0.2s, box-shadow 0.2s;

--- a/src/assets/css/pdf-a-go-go.css
+++ b/src/assets/css/pdf-a-go-go.css
@@ -490,6 +490,7 @@
   z-index: 1;
   pointer-events: none;
 }
+/* Text layer for text selection */
 .pdfagogo-text-layer {
   position: absolute;
   top: 0;
@@ -497,12 +498,9 @@
   right: 0;
   bottom: 0;
   overflow: hidden;
-  opacity: 0.2;
   line-height: 1.0;
   pointer-events: auto;
-  mix-blend-mode: multiply;
   border-radius: 8px;
-  transition: opacity 0.2s ease-in-out;
   user-select: text;
   -webkit-user-select: text;
   -moz-user-select: text;
@@ -522,35 +520,16 @@
   -ms-user-select: text;
   -webkit-touch-callout: text;
   touch-action: auto;
+  line-height: 1.0;
 }
-/* Show text on selection */
+/* Show selection highlight */
 .pdfagogo-text-layer span::selection {
-  background: rgba(0, 0, 255, 0.3) !important;
-  color: transparent !important;
+  background: rgba(0, 100, 255, 0.35);
+  color: transparent;
 }
 .pdfagogo-text-layer span::-moz-selection {
-  background: rgba(0, 0, 255, 0.3) !important;
-  color: transparent !important;
-}
-/* Make text visible on hover for accessibility */
-.pdfagogo-text-layer:hover {
-  opacity: 0.7;
-  background: rgba(255, 255, 255, 0.95);
-  mix-blend-mode: normal;
-  pointer-events: auto;
-}
-/* For debugging */
-/* .pdfagogo-text-layer:hover span {
-  color: rgba(0, 0, 0, 0.8);
-} */
-/* Improve visibility on mobile */
-@media (max-width: 768px) {
-  .pdfagogo-text-layer {
-    opacity: 0.15;
-  }
-  .pdfagogo-text-layer:hover {
-    opacity: 0.8;
-  }
+  background: rgba(0, 100, 255, 0.35);
+  color: transparent;
 }
 .pdfagogo-scroll-container::-webkit-scrollbar {
   height: 8px;

--- a/src/assets/js/pdfagogo.js
+++ b/src/assets/js/pdfagogo.js
@@ -215,6 +215,7 @@ function init(book, id, opts, cb) {
     if (map.marginLeft) opts.marginLeft = parseFloat(map.marginLeft);
 
     // UI feature toggles
+    if (map.showToolbar !== undefined) opts.showToolbar = parseBool(map.showToolbar, undefined);
     if (map.showPageSelector !== undefined) opts.showPageSelector = parseBool(map.showPageSelector, undefined);
     if (map.showCurrentPage !== undefined) opts.showCurrentPage = parseBool(map.showCurrentPage, undefined);
     if (map.showSearch !== undefined) opts.showSearch = parseBool(map.showSearch, undefined);
@@ -359,8 +360,7 @@ function init(book, id, opts, cb) {
                     hl.y + hl.height
                   ]);
                   const left = Math.min(rect[0], rect[2]);
-                  let top = Math.min(rect[1], rect[3]);
-                  top -= 8; // Slight vertical adjustment for better visibility
+                  const top = Math.min(rect[1], rect[3]);
                   const width = Math.abs(rect[2] - rect[0]);
                   const height = Math.abs(rect[3] - rect[1]);
                   context.fillRect(left, top, width, height);

--- a/src/assets/js/scrollablePdfViewer.js
+++ b/src/assets/js/scrollablePdfViewer.js
@@ -263,6 +263,9 @@ export class ScrollablePdfViewer extends EventEmitter {
     /** @type {Object<number, HTMLCanvasElement>} Cache of rendered page canvases */
     this.pageCanvases = {};
 
+    /** @type {Object<number, HTMLDivElement>} Cache of text layer elements */
+    this.textLayers = {};
+
     /** @type {RenderQueue} Queue for managing rendering tasks */
     this.renderQueue = new RenderQueue();
 
@@ -471,8 +474,15 @@ export class ScrollablePdfViewer extends EventEmitter {
         canvas.setAttribute("data-page", i + 1);
         canvas.setAttribute("data-resolution", "placeholder");
 
+        // Create text layer for text selection
+        const textLayer = document.createElement("div");
+        textLayer.className = "pdfagogo-text-layer";
+        textLayer.setAttribute("data-page", i + 1);
+
         wrapper.appendChild(canvas);
+        wrapper.appendChild(textLayer);
         this.pageCanvases[i] = canvas;
+        this.textLayers[i] = textLayer;
         offscreenContainer.appendChild(wrapper);
       }
 
@@ -632,8 +642,70 @@ export class ScrollablePdfViewer extends EventEmitter {
         console.log(`%c   Canvas: ${canvas.width}×${canvas.height} (display scale: ${scale.toFixed(2)}x, DPR: ${devicePixelRatio})`, 'color: #2196F3;');
       }
 
+      // Render text layer for text selection
+      this._renderTextLayer(ndx, pg, targetWidth, height);
+
       if (callback) callback();
     }, highlights, scale);
+  }
+
+  /**
+   * Render text layer for a page to enable text selection and copy.
+   * @param {number} ndx - Page index (0-based)
+   * @param {Object} pg - Page object with getTextContent and getViewport methods
+   * @param {number} displayWidth - Display width in CSS pixels
+   * @param {number} displayHeight - Display height in CSS pixels
+   */
+  async _renderTextLayer(ndx, pg, displayWidth, displayHeight) {
+    const textLayer = this.textLayers[ndx];
+    if (!textLayer || !pg.getTextContent) return;
+
+    // Clear existing text content
+    textLayer.innerHTML = '';
+
+    try {
+      const textContent = await pg.getTextContent();
+      if (!textContent || !textContent.items || textContent.items.length === 0) return;
+
+      // Get viewport for coordinate transformation
+      const viewport = pg.getViewport({ scale: 1 });
+      const scaleX = displayWidth / viewport.width;
+      const scaleY = displayHeight / viewport.height;
+
+      // Create spans for each text item
+      for (const item of textContent.items) {
+        if (!item.str || item.str.trim() === '') continue;
+
+        const span = document.createElement('span');
+        span.textContent = item.str;
+
+        // Calculate position from transform matrix
+        // PDF.js transform: [scaleX, skewX, skewY, scaleY, translateX, translateY]
+        const tx = item.transform[4];
+        const ty = item.transform[5];
+        const fontSize = Math.sqrt(item.transform[0] * item.transform[0] + item.transform[1] * item.transform[1]);
+
+        // Convert PDF coordinates to display coordinates
+        // PDF origin is bottom-left, we need top-left
+        const left = tx * scaleX;
+        const top = (viewport.height - ty) * scaleY - (fontSize * scaleY);
+
+        span.style.left = `${left}px`;
+        span.style.top = `${top}px`;
+        span.style.fontSize = `${fontSize * scaleY}px`;
+
+        // Handle text direction and width
+        if (item.width) {
+          span.style.width = `${item.width * scaleX}px`;
+        }
+
+        textLayer.appendChild(span);
+      }
+    } catch (err) {
+      if (this.debug) {
+        console.warn(`[PDF-A-go-go] Failed to render text layer for page ${ndx + 1}:`, err);
+      }
+    }
   }
 
   _updateVisiblePages() {
@@ -748,6 +820,12 @@ export class ScrollablePdfViewer extends EventEmitter {
           ctx.clearRect(0, 0, canvas.width, canvas.height);
           canvas.width = canvas.height = 32;
           canvas.setAttribute('data-resolution', 'placeholder');
+
+          // Clear corresponding text layer
+          const textLayer = this.textLayers[pageNum];
+          if (textLayer) {
+            textLayer.innerHTML = '';
+          }
 
           if (this.debug) {
             this.metrics.memoryUsage[pageNum] = {

--- a/src/assets/js/search.js
+++ b/src/assets/js/search.js
@@ -25,42 +25,37 @@ export function setupSearchControls(container, featureOptions, viewer, book, pdf
     return;
   }
 
-  // Remove any existing search controls to avoid duplicates
-  const existing = document.querySelector('.pdfagogo-search-controls');
-  if (existing && existing.parentNode) existing.parentNode.removeChild(existing);
-
-  // Build the search UI
-  const searchControls = document.createElement('div');
-  searchControls.className = 'pdfagogo-search-controls';
-  searchControls.innerHTML = `
-    <input class="pdfagogo-search-box" type="text" placeholder="Search text..." aria-label="Search text" />
-    <button class="pdfagogo-search-btn">Search</button>
-    <button class="pdfagogo-search-clear-btn" aria-label="Clear search" title="Clear search">Clear</button>
-    <span class="pdfagogo-search-result"></span>
-    <button class="pdfagogo-prev-match-btn" aria-label="Previous match" disabled>Prev</button>
-    <button class="pdfagogo-next-match-btn" aria-label="Next match" disabled>Next</button>
-  `;
-  // Prefer inserting search controls inside the main controls container if present
-  const controlsContainer = document.querySelector('.pdfagogo-controls');
-  if (controlsContainer) {
-    // Place search controls at the top of the controls container
-    controlsContainer.insertBefore(searchControls, controlsContainer.firstChild);
-  } else if (container && container.parentNode) {
-    // Fallback to previous behavior if controls container isn't available yet
-    container.parentNode.insertBefore(searchControls, container);
+  // Find the toolbar center section to insert search controls
+  const toolbarCenter = container.querySelector('.pdfagogo-toolbar-center');
+  if (!toolbarCenter) {
+    console.warn('PDF-A-go-go: Toolbar center section not found, search disabled');
+    return;
   }
 
-  const searchBox = searchControls.querySelector('.pdfagogo-search-box');
-  const searchBtn = searchControls.querySelector('.pdfagogo-search-btn');
+  // Remove any existing search controls to avoid duplicates
+  toolbarCenter.innerHTML = '';
+
+  // Build the search UI - inline in toolbar
+  // Icons from Lucide (https://lucide.dev) - MIT License
+  const searchControls = document.createElement('div');
+  searchControls.className = 'pdfagogo-search-group';
+  searchControls.innerHTML = `
+    <input class="pdfagogo-search-input" type="text" placeholder="Search..." aria-label="Search in document" />
+    <span class="pdfagogo-search-result"></span>
+    <button class="pdfagogo-prev-match-btn" aria-label="Previous match" title="Previous (Shift+Enter)"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m18 15-6-6-6 6"/></svg></button>
+    <button class="pdfagogo-next-match-btn" aria-label="Next match" title="Next (Enter)"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+  `;
+  toolbarCenter.appendChild(searchControls);
+
+  const searchBox = searchControls.querySelector('.pdfagogo-search-input');
   const searchResult = searchControls.querySelector('.pdfagogo-search-result');
   const prevMatchBtn = searchControls.querySelector('.pdfagogo-prev-match-btn');
   const nextMatchBtn = searchControls.querySelector('.pdfagogo-next-match-btn');
-  const clearBtn = searchControls.querySelector('.pdfagogo-search-clear-btn');
 
-  // Hide navigation buttons until a search is active with results
+  // Initially hide result count and nav buttons
+  if (searchResult) searchResult.style.display = 'none';
   if (prevMatchBtn) prevMatchBtn.style.display = 'none';
   if (nextMatchBtn) nextMatchBtn.style.display = 'none';
-  if (clearBtn) clearBtn.style.display = 'none';
 
   // --- Search state ---
   let matchPages = [];
@@ -91,8 +86,9 @@ export function setupSearchControls(container, featureOptions, viewer, book, pdf
           const idx = itemText.indexOf(query);
           if (idx !== -1) {
             const x = item.transform[4];
-            const y = item.transform[5] - (item.height || 10);
-            boxes.push({ x, y, width: item.width, height: item.height || 10 });
+            const y = item.transform[5];
+            const h = item.height || 12;
+            boxes.push({ x, y, width: item.width, height: h });
           }
         }
         matchHighlights[i] = boxes;
@@ -103,6 +99,10 @@ export function setupSearchControls(container, featureOptions, viewer, book, pdf
   function showMatch(idx) {
     if (matchPages.length === 0) {
       window.__pdfagogo__highlights = {};
+      if (searchResult) {
+        searchResult.textContent = 'No matches';
+        searchResult.style.display = '';
+      }
       if (prevMatchBtn) {
         prevMatchBtn.disabled = true;
         prevMatchBtn.style.display = 'none';
@@ -140,46 +140,41 @@ export function setupSearchControls(container, featureOptions, viewer, book, pdf
       viewer.go_to_page(viewer.currentPage || 0);
     }
 
+    // Update result count (compact format)
     if (searchResult) {
-      searchResult.textContent = `Match set ${currentMatchIdx + 1} of ${matchPages.length} (page ${pageNum})`;
+      searchResult.textContent = `${currentMatchIdx + 1} / ${matchPages.length}`;
+      searchResult.style.display = '';
     }
 
+    // Show navigation buttons
     if (prevMatchBtn) {
-      prevMatchBtn.disabled = matchPages.length <= 1;
+      prevMatchBtn.disabled = false;
       prevMatchBtn.style.display = '';
     }
     if (nextMatchBtn) {
-      nextMatchBtn.disabled = matchPages.length <= 1;
+      nextMatchBtn.disabled = false;
       nextMatchBtn.style.display = '';
-    }
-    if (clearBtn) {
-      clearBtn.style.display = '';
     }
   }
 
-  if (searchBtn)
-    searchBtn.onclick = async function () {
-      const query = searchBox ? searchBox.value.trim().toLowerCase() : '';
-      if (!query) return;
-      if (searchResult) searchResult.textContent = 'Searching...';
-      await searchPdf(query);
-      lastQuery = query;
-      if (matchPages.length > 0) {
-        showMatch(0);
-      } else {
-        if (searchResult) searchResult.textContent = 'Not found';
-        if (prevMatchBtn) {
-          prevMatchBtn.disabled = true;
-          prevMatchBtn.style.display = 'none';
-        }
-        if (nextMatchBtn) {
-          nextMatchBtn.disabled = true;
-          nextMatchBtn.style.display = 'none';
-        }
-        if (clearBtn) clearBtn.style.display = '';
-      }
-    };
+  // Search function - triggered on Enter
+  async function doSearch() {
+    const query = searchBox ? searchBox.value.trim().toLowerCase() : '';
+    if (!query) return;
+    if (searchResult) {
+      searchResult.textContent = '...';
+      searchResult.style.display = '';
+    }
+    await searchPdf(query);
+    lastQuery = query;
+    if (matchPages.length > 0) {
+      showMatch(0);
+    } else {
+      showMatch(-1); // Will show "No matches"
+    }
+  }
 
+  // Navigation button handlers
   if (prevMatchBtn)
     prevMatchBtn.onclick = function () {
       showMatch(currentMatchIdx - 1);
@@ -190,70 +185,73 @@ export function setupSearchControls(container, featureOptions, viewer, book, pdf
       showMatch(currentMatchIdx + 1);
     };
 
-  if (searchBox)
+  // Keyboard handling
+  if (searchBox) {
     searchBox.addEventListener('keydown', function (e) {
       if (e.key === 'Enter') {
+        e.preventDefault();
         const query = searchBox.value.trim().toLowerCase();
         if (query && query === lastQuery && matchPages.length > 0) {
+          // Same query - navigate matches
           if (e.shiftKey) {
             showMatch(currentMatchIdx - 1);
           } else {
             showMatch(currentMatchIdx + 1);
           }
-        } else if (searchBtn) {
-          searchBtn.click();
+        } else {
+          // New query - search
+          doSearch();
         }
       } else if (e.key === 'Escape') {
-        if (clearBtn && clearBtn.style.display !== 'none') {
-          clearBtn.click();
-        } else if (searchBox && searchBox.value) {
-          // If clear button is hidden but there is text, clear the input
-          searchBox.value = '';
-          if (searchResult) searchResult.textContent = '';
-          if (prevMatchBtn) prevMatchBtn.style.display = 'none';
-          if (nextMatchBtn) nextMatchBtn.style.display = 'none';
-          if (clearBtn) clearBtn.style.display = 'none';
-        }
+        clearSearch();
       }
     });
 
-  // When typing a new query, hide the nav buttons until search runs again
-  if (searchBox) {
+    // Live search as user types (debounced)
+    let searchTimeout = null;
     searchBox.addEventListener('input', function () {
+      // Hide results while typing
+      if (searchResult) searchResult.style.display = 'none';
       if (prevMatchBtn) prevMatchBtn.style.display = 'none';
       if (nextMatchBtn) nextMatchBtn.style.display = 'none';
-      if (clearBtn) clearBtn.style.display = searchBox.value.trim() ? '' : 'none';
+
+      // Debounce search
+      clearTimeout(searchTimeout);
+      const query = searchBox.value.trim();
+      if (query.length >= 2) {
+        searchTimeout = setTimeout(doSearch, 300);
+      }
     });
   }
 
-  // Clear/end the current search and reset UI
-  if (clearBtn) {
-    clearBtn.onclick = function () {
-      lastQuery = '';
-      matchPages = [];
-      currentMatchIdx = 0;
-      if (searchBox) searchBox.value = '';
-      if (searchResult) searchResult.textContent = '';
-      // clear highlights and rerender affected page(s)
-      const pageToClear = prevMatchPage;
-      window.__pdfagogo__highlights = {};
-      if (typeof viewer.rerenderPage === 'function') {
-        if (typeof pageToClear === 'number') {
-          viewer.rerenderPage(pageToClear);
-        }
-      } else if (typeof viewer._renderAllPages === 'function') {
-        viewer._renderAllPages();
+  // Clear search function
+  function clearSearch() {
+    lastQuery = '';
+    matchPages = [];
+    currentMatchIdx = 0;
+    if (searchBox) searchBox.value = '';
+    if (searchResult) {
+      searchResult.textContent = '';
+      searchResult.style.display = 'none';
+    }
+    // Clear highlights and rerender affected page(s)
+    const pageToClear = prevMatchPage;
+    window.__pdfagogo__highlights = {};
+    if (typeof viewer.rerenderPage === 'function') {
+      if (typeof pageToClear === 'number') {
+        viewer.rerenderPage(pageToClear);
       }
-      if (prevMatchBtn) {
-        prevMatchBtn.disabled = true;
-        prevMatchBtn.style.display = 'none';
-      }
-      if (nextMatchBtn) {
-        nextMatchBtn.disabled = true;
-        nextMatchBtn.style.display = 'none';
-      }
-      if (clearBtn) clearBtn.style.display = 'none';
-    };
+    } else if (typeof viewer._renderAllPages === 'function') {
+      viewer._renderAllPages();
+    }
+    if (prevMatchBtn) {
+      prevMatchBtn.disabled = true;
+      prevMatchBtn.style.display = 'none';
+    }
+    if (nextMatchBtn) {
+      nextMatchBtn.disabled = true;
+      nextMatchBtn.style.display = 'none';
+    }
   }
 }
 

--- a/src/assets/js/ui.js
+++ b/src/assets/js/ui.js
@@ -289,7 +289,7 @@ import { setupSearchControls } from './search.js';
 export function setupControls(container, featureOptions, viewer, book, pdf) {
   // Remove any existing controls to prevent duplicates
   [
-    "pdfagogo-search-controls",
+    "pdfagogo-toolbar",
     "pdfagogo-controls",
     "pdfagogo-page-announcement",
     "pdfagogo-a11y-instructions"
@@ -313,31 +313,52 @@ export function setupControls(container, featureOptions, viewer, book, pdf) {
   // Search controls are handled by the dedicated module
   let setPageByNumber = null; // will be defined below then passed into search module
 
-  // Main controls
-  const controls = document.createElement("div");
-  controls.className = "pdfagogo-controls";
-  let controlsHTML = "";
-  if (featureOptions.showShare !== false) {
-    controlsHTML += '<button class="pdfagogo-share" aria-label="Share current page">Share</button>';
+  // Check if toolbar should be shown (default: true)
+  const showToolbar = featureOptions.showToolbar !== false;
+
+  // Create unified top toolbar (inside the container)
+  const toolbar = document.createElement("div");
+  toolbar.className = "pdfagogo-toolbar";
+  if (!showToolbar) {
+    toolbar.style.display = 'none';
   }
+
+  let toolbarHTML = '';
+
+  // Left section: page navigation with prev/next buttons and editable page input
+  // Icons from Lucide (https://lucide.dev) - MIT License
+  toolbarHTML += '<div class="pdfagogo-toolbar-section pdfagogo-toolbar-left">';
+  if (featureOptions.showPageSelector !== false || featureOptions.showCurrentPage !== false) {
+    toolbarHTML += '<div class="pdfagogo-page-nav">';
+    toolbarHTML += '<button class="pdfagogo-prev-page" aria-label="Previous page" title="Previous page"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m15 18-6-6 6-6"/></svg></button>';
+    toolbarHTML += '<input class="pdfagogo-goto-page" type="text" inputmode="numeric" pattern="\\d*" min="1" aria-label="Current page" title="Go to page" />';
+    toolbarHTML += '<span class="pdfagogo-page-total" aria-live="polite"></span>';
+    toolbarHTML += '<button class="pdfagogo-next-page" aria-label="Next page" title="Next page"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg></button>';
+    toolbarHTML += '</div>';
+  }
+  toolbarHTML += '</div>';
+
+  // Center section: search (handled by search module, placeholder for spacing)
+  toolbarHTML += '<div class="pdfagogo-toolbar-section pdfagogo-toolbar-center"></div>';
+
+  // Right section: zoom + actions
+  // Icons from Lucide (https://lucide.dev) - MIT License
+  toolbarHTML += '<div class="pdfagogo-toolbar-section pdfagogo-toolbar-right">';
+  toolbarHTML += '<span class="pdfagogo-zoom-indicator" aria-live="polite"></span>';
   if (featureOptions.showDownload) {
-    controlsHTML += '<button class="pdfagogo-download" aria-label="Download PDF">Download PDF</button>';
+    toolbarHTML += '<button class="pdfagogo-download" aria-label="Download PDF" title="Download PDF"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 15V3"/><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><path d="m7 10 5 5 5-5"/></svg></button>';
   }
   if (featureOptions.showFullscreen !== false) {
-    controlsHTML += '<button class="pdfagogo-fullscreen" aria-label="Enter fullscreen" title="Enter fullscreen">Fullscreen</button>';
+    toolbarHTML += '<button class="pdfagogo-fullscreen" aria-label="Fullscreen" title="Fullscreen"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 3H5a2 2 0 0 0-2 2v3"/><path d="M21 8V5a2 2 0 0 0-2-2h-3"/><path d="M3 16v3a2 2 0 0 0 2 2h3"/><path d="M16 21h3a2 2 0 0 0 2-2v-3"/></svg></button>';
   }
-  if (featureOptions.showPageSelector) {
-    controlsHTML +=
-      '<input class="pdfagogo-goto-page" type="number" min="0" max="999" style="width:60px;" placeholder="Page #" aria-label="Go to page" />';
-    controlsHTML += '<button class="pdfagogo-goto-btn">Go</button>';
+  if (featureOptions.showShare !== false) {
+    toolbarHTML += '<button class="pdfagogo-share" aria-label="Share link" title="Copy link to this page"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg></button>';
   }
-  if (featureOptions.showCurrentPage) {
-    controlsHTML +=
-      '<span class="pdfagogo-page-indicator" aria-live="polite"></span>';
-  }
-  controls.innerHTML = controlsHTML;
-  // Insert controls inside the wrapper (below the container)
-  wrapper.insertBefore(controls, container.nextSibling);
+  toolbarHTML += '</div>';
+
+  toolbar.innerHTML = toolbarHTML;
+  // Insert toolbar at the top of the container
+  container.insertBefore(toolbar, container.firstChild);
 
   // Page announcement for screen readers
   let pageAnnouncement = wrapper.querySelector(".pdfagogo-page-announcement");
@@ -351,26 +372,27 @@ export function setupControls(container, featureOptions, viewer, book, pdf) {
     pageAnnouncement.style.height = "1px";
     pageAnnouncement.style.overflow = "hidden";
     pageAnnouncement.setAttribute("aria-live", "polite");
-    wrapper.insertBefore(pageAnnouncement, controls.nextSibling);
+    wrapper.appendChild(pageAnnouncement);
   }
 
-  // Accessibility instructions (visible block can be toggled by featureOptions)
+  // Accessibility instructions (collapsible, visible block can be toggled by featureOptions)
   let a11yInstructions = wrapper.querySelector(".pdfagogo-a11y-instructions");
   if (!a11yInstructions && featureOptions.showAccessibilityControlsVisibly) {
-    a11yInstructions = document.createElement("div");
+    a11yInstructions = document.createElement("details");
     a11yInstructions.className = "pdfagogo-a11y-instructions";
-    a11yInstructions.setAttribute("aria-live", "polite");
     a11yInstructions.innerHTML = `
-      <strong>Accessibility:</strong><br>
-      - Use <kbd>Tab</kbd> to focus the reader.<br>
-      - Use <kbd>Up or Left Arrow</kbd> to go to the previous page.<br>
-      - Use <kbd>Down or Right Arrow</kbd> to go to the next page.<br>
-      - Use <kbd>+</kbd> or <kbd>-</kbd> to zoom in/out.<br>
-      - Use the buttons above for navigation, sharing, and searching.<br>
-      - The current page is announced for screen readers.
+      <summary>Keyboard shortcuts</summary>
+      <ul>
+        <li><kbd>Tab</kbd> to focus the viewer</li>
+        <li><kbd>↑</kbd> / <kbd>←</kbd> previous page</li>
+        <li><kbd>↓</kbd> / <kbd>→</kbd> next page</li>
+        <li><kbd>Ctrl</kbd>+<kbd>+</kbd> / <kbd>-</kbd> zoom in/out</li>
+        <li><kbd>Ctrl</kbd>+<kbd>0</kbd> reset zoom</li>
+        <li><kbd>Ctrl</kbd>+<kbd>F</kbd> search</li>
+      </ul>
     `;
-    // Place a11y instructions below the container as well, after controls
-    wrapper.insertBefore(a11yInstructions, controls.nextSibling);
+    // Place a11y instructions below the container
+    wrapper.appendChild(a11yInstructions);
   } else if (a11yInstructions && !featureOptions.showAccessibilityControlsVisibly) {
     // If present but disabled, remove from DOM
     if (a11yInstructions.parentNode) a11yInstructions.parentNode.removeChild(a11yInstructions);
@@ -382,17 +404,25 @@ export function setupControls(container, featureOptions, viewer, book, pdf) {
   // --- Event wiring and logic ---
 
   // Share button
-  const shareBtn = controls.querySelector(".pdfagogo-share");
-  if (shareBtn)
+  // Icons from Lucide (https://lucide.dev) - MIT License
+  const shareBtn = toolbar.querySelector(".pdfagogo-share");
+  if (shareBtn) {
+    const originalHTML = shareBtn.innerHTML;
     shareBtn.onclick = () => {
       const page = currentPage + 1;
       const shareUrl = `${window.location.origin}${window.location.pathname}#pdf-page-${page}`;
       navigator.clipboard.writeText(shareUrl);
-      alert("Share link copied to clipboard:\n" + shareUrl);
+      shareBtn.innerHTML = '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>';
+      shareBtn.classList.add("copied");
+      setTimeout(() => {
+        shareBtn.innerHTML = originalHTML;
+        shareBtn.classList.remove("copied");
+      }, 1500);
     };
+  }
 
   // Download button
-  const downloadBtn = controls.querySelector(".pdfagogo-download");
+  const downloadBtn = toolbar.querySelector(".pdfagogo-download");
   if (downloadBtn) {
     downloadBtn.onclick = () => {
       const link = document.createElement('a');
@@ -405,13 +435,17 @@ export function setupControls(container, featureOptions, viewer, book, pdf) {
   }
 
   // Fullscreen button
-  const fullscreenBtn = controls.querySelector('.pdfagogo-fullscreen');
+  // Icons from Lucide (https://lucide.dev) - MIT License
+  const fullscreenBtn = toolbar.querySelector('.pdfagogo-fullscreen');
   if (fullscreenBtn) {
+    const fsIconEnter = '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 3H5a2 2 0 0 0-2 2v3"/><path d="M21 8V5a2 2 0 0 0-2-2h-3"/><path d="M3 16v3a2 2 0 0 0 2 2h3"/><path d="M16 21h3a2 2 0 0 0 2-2v-3"/></svg>';
+    const fsIconExit = '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 3v3a2 2 0 0 1-2 2H3"/><path d="M21 8h-3a2 2 0 0 1-2-2V3"/><path d="M3 16h3a2 2 0 0 1 2 2v3"/><path d="M16 21v-3a2 2 0 0 1 2-2h3"/></svg>';
     const updateFsButton = () => {
       const isFs = !!document.fullscreenElement && wrapper === document.fullscreenElement;
-      fullscreenBtn.textContent = isFs ? 'Exit Fullscreen' : 'Fullscreen';
+      fullscreenBtn.innerHTML = isFs ? fsIconExit : fsIconEnter;
       fullscreenBtn.setAttribute('aria-label', isFs ? 'Exit fullscreen' : 'Enter fullscreen');
       fullscreenBtn.title = isFs ? 'Exit fullscreen' : 'Enter fullscreen';
+      fullscreenBtn.classList.toggle('active', isFs);
     };
     fullscreenBtn.onclick = () => {
       if (document.fullscreenElement) {
@@ -424,9 +458,12 @@ export function setupControls(container, featureOptions, viewer, book, pdf) {
     updateFsButton();
   }
 
-  // Page selector
-  const gotoPageInput = controls.querySelector(".pdfagogo-goto-page");
-  const gotoBtn = controls.querySelector(".pdfagogo-goto-btn");
+  // Page navigation elements
+  const gotoPageInput = toolbar.querySelector(".pdfagogo-goto-page");
+  const pageTotalSpan = toolbar.querySelector(".pdfagogo-page-total");
+  const prevPageBtn = toolbar.querySelector(".pdfagogo-prev-page");
+  const nextPageBtn = toolbar.querySelector(".pdfagogo-next-page");
+
   function baseSetPageByNumber(pageNum) {
     if (!viewer || !book) return;
     if (
@@ -435,7 +472,11 @@ export function setupControls(container, featureOptions, viewer, book, pdf) {
       pageNum < 1 ||
       pageNum > book.numPages()
     ) {
-      alert("Invalid page number");
+      // Flash the input to indicate invalid value
+      if (gotoPageInput) {
+        gotoPageInput.classList.add("invalid");
+        setTimeout(() => gotoPageInput.classList.remove("invalid"), 500);
+      }
       return;
     }
     if (typeof viewer.go_to_page === "function") {
@@ -443,42 +484,85 @@ export function setupControls(container, featureOptions, viewer, book, pdf) {
       return;
     }
   }
+
   // Initialize the navigation function variable
   setPageByNumber = baseSetPageByNumber;
-  if (gotoBtn)
-    gotoBtn.onclick = function () {
-      const val = gotoPageInput ? parseInt(gotoPageInput.value, 10) : NaN;
+
+  // Page input change handler
+  if (gotoPageInput) {
+    gotoPageInput.addEventListener('change', function() {
+      const val = parseInt(gotoPageInput.value, 10);
       setPageByNumber(val);
-    };
-  if (gotoPageInput && gotoBtn) {
-    gotoPageInput.addEventListener('keydown', function(e) {
-      if (e.key === 'Enter' || e.keyCode === 13) {
-        gotoBtn.click();
-      }
+    });
+    // Select all text on focus for easy editing
+    gotoPageInput.addEventListener('focus', function() {
+      gotoPageInput.select();
     });
   }
-  if (!featureOptions.showPageSelector) {
-    if (gotoPageInput) gotoPageInput.style.display = "none";
-    if (gotoBtn) gotoBtn.style.display = "none";
+
+  // Prev/Next page buttons
+  if (prevPageBtn) {
+    prevPageBtn.onclick = () => {
+      if (currentPage > 1) {
+        setPageByNumber(currentPage - 1);
+      }
+    };
+  }
+  if (nextPageBtn) {
+    nextPageBtn.onclick = () => {
+      if (currentPage < book.numPages()) {
+        setPageByNumber(currentPage + 1);
+      }
+    };
   }
 
-  // Current page indicator
-  const pageIndicator = controls.querySelector(
-    ".pdfagogo-page-indicator"
-  );
+  // Update page display and button states
   function updatePage(n) {
     currentPage = parseInt(n);
     const totalPages = book.numPages();
-    if (pageIndicator)
-      pageIndicator.textContent = `Page: ${currentPage} / ${totalPages}`;
-    if (pageAnnouncement)
+
+    // Update input with current page
+    if (gotoPageInput) {
+      gotoPageInput.value = currentPage;
+    }
+
+    // Update total pages display
+    if (pageTotalSpan) {
+      pageTotalSpan.textContent = totalPages;
+    }
+
+    // Update prev/next button states
+    if (prevPageBtn) {
+      prevPageBtn.disabled = currentPage <= 1;
+      prevPageBtn.classList.toggle('disabled', currentPage <= 1);
+    }
+    if (nextPageBtn) {
+      nextPageBtn.disabled = currentPage >= totalPages;
+      nextPageBtn.classList.toggle('disabled', currentPage >= totalPages);
+    }
+
+    // Screen reader announcement
+    if (pageAnnouncement) {
       pageAnnouncement.textContent = `Page ${currentPage} of ${totalPages}`;
+    }
   }
   viewer.on("seen", updatePage);
   updatePage(1); // Start at page 1 since that's what's initially visible
-  if (!featureOptions.showCurrentPage) {
-    if (pageIndicator) pageIndicator.style.display = "none";
-  }
+
+  // Zoom indicator - show when zoomed, hide at 100%
+  const zoomIndicator = toolbar.querySelector(".pdfagogo-zoom-indicator");
+  if (zoomIndicator) zoomIndicator.style.display = "none"; // Hidden by default
+  viewer.on("zoom", ({ level, percentage }) => {
+    if (zoomIndicator) {
+      if (Math.abs(level - 1.0) < 0.01) {
+        // At or very close to 100%, hide indicator
+        zoomIndicator.style.display = "none";
+      } else {
+        zoomIndicator.style.display = "";
+        zoomIndicator.textContent = `${percentage}%`;
+      }
+    }
+  });
 
   // Initialize search controls (delegated to search module)
   setupSearchControls(container, featureOptions, viewer, book, pdf, setPageByNumber);

--- a/src/index.html
+++ b/src/index.html
@@ -24,9 +24,10 @@
          data-show-prev-next="true"
          data-show-page-selector="true"
          data-show-current-page="true"
+         data-default-page="3"
          data-show-download="true"
-         data-show-share="false"
-         data-show-accessibility-controls-visibly="true"
+         data-show-share="true"
+         data-show-accessibility-controls-visibly="false"
          disabled-data-momentum="2"
          data-debug="false"
         >

--- a/src/tests/fullscreen.spec.ts
+++ b/src/tests/fullscreen.spec.ts
@@ -15,13 +15,16 @@ test.describe('PDF-A-go-go Fullscreen Control', () => {
     // Ensure the wrapper and button exist
     const hasElements = await page.evaluate(() => {
       const wrapper = document.querySelector('.pdfagogo-viewer-wrapper');
-      const btn = document.querySelector<HTMLButtonElement>('.pdfagogo-controls .pdfagogo-fullscreen');
-      return { hasWrapper: !!wrapper, hasBtn: !!btn, btnText: btn?.textContent?.trim() };
+      const btn = document.querySelector<HTMLButtonElement>('.pdfagogo-toolbar .pdfagogo-fullscreen');
+      // Check for SVG icon or any content
+      const hasContent = btn ? (btn.querySelector('svg') !== null || btn.textContent?.trim()) : false;
+      return { hasWrapper: !!wrapper, hasBtn: !!btn, hasContent };
     });
 
     expect(hasElements.hasWrapper).toBe(true);
     expect(hasElements.hasBtn).toBe(true);
-    expect(hasElements.btnText).toMatch(/Fullscreen|Exit Fullscreen/i);
+    // Button now uses SVG icon
+    expect(hasElements.hasContent).toBeTruthy();
 
     // Stub requestFullscreen to verify it is called
     await page.evaluate(() => {
@@ -36,7 +39,7 @@ test.describe('PDF-A-go-go Fullscreen Control', () => {
     });
 
     // Click the fullscreen button
-    await page.click('.pdfagogo-controls .pdfagogo-fullscreen');
+    await page.click('.pdfagogo-toolbar .pdfagogo-fullscreen');
 
     // Verify our stub was invoked
     const fsRequested = await page.evaluate(() => (window as any).__fsRequested === true);

--- a/src/tests/text-selection.spec.ts
+++ b/src/tests/text-selection.spec.ts
@@ -1,0 +1,224 @@
+import { test, expect, Page } from '@playwright/test';
+
+// Helper function to wait for PDF to fully load
+async function waitForPdfLoad(page: Page) {
+  await page.waitForSelector('.pdfagogo-page-canvas', { timeout: 10000 });
+  await page.waitForTimeout(2000); // Allow time for initial render and text layer
+}
+
+// Helper function to check if text layer exists
+async function hasTextLayer(page: Page): Promise<boolean> {
+  return await page.evaluate(() => {
+    const textLayers = document.querySelectorAll('.pdfagogo-text-layer');
+    return textLayers.length > 0;
+  });
+}
+
+// Helper function to check if text layer has content
+async function textLayerHasContent(page: Page): Promise<boolean> {
+  return await page.evaluate(() => {
+    const textLayers = document.querySelectorAll('.pdfagogo-text-layer');
+    for (const layer of textLayers) {
+      if (layer.children.length > 0) return true;
+    }
+    return false;
+  });
+}
+
+// Helper function to get text layer span count
+async function getTextLayerSpanCount(page: Page): Promise<number> {
+  return await page.evaluate(() => {
+    let count = 0;
+    const textLayers = document.querySelectorAll('.pdfagogo-text-layer');
+    textLayers.forEach(layer => {
+      count += layer.querySelectorAll('span').length;
+    });
+    return count;
+  });
+}
+
+// Helper function to select text via mouse drag
+async function selectTextByDrag(page: Page, startX: number, startY: number, endX: number, endY: number) {
+  await page.mouse.move(startX, startY);
+  await page.mouse.down();
+  await page.mouse.move(endX, endY);
+  await page.mouse.up();
+}
+
+// Helper function to get selected text
+async function getSelectedText(page: Page): Promise<string> {
+  return await page.evaluate(() => {
+    const selection = window.getSelection();
+    return selection ? selection.toString() : '';
+  });
+}
+
+test.describe('PDF-A-go-go Text Selection', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('http://localhost:9000/');
+    await waitForPdfLoad(page);
+  });
+
+  test('Text layer elements are created for each page', async ({ page }) => {
+    const hasLayers = await hasTextLayer(page);
+    expect(hasLayers).toBe(true);
+  });
+
+  test('Text layer contains span elements after render', async ({ page }) => {
+    // Wait a bit more for text layer to populate
+    await page.waitForTimeout(1000);
+
+    const hasContent = await textLayerHasContent(page);
+    expect(hasContent).toBe(true);
+  });
+
+  test('Text layer spans have correct CSS properties', async ({ page }) => {
+    await page.waitForTimeout(1000);
+
+    const spanStyles = await page.evaluate(() => {
+      const span = document.querySelector('.pdfagogo-text-layer span') as HTMLElement;
+      if (!span) return null;
+
+      const styles = window.getComputedStyle(span);
+      return {
+        position: styles.position,
+        color: styles.color,
+        cursor: styles.cursor,
+        userSelect: styles.userSelect || (styles as any).webkitUserSelect,
+      };
+    });
+
+    expect(spanStyles).not.toBeNull();
+    expect(spanStyles?.position).toBe('absolute');
+    // Text should be transparent (invisible but selectable)
+    expect(spanStyles?.color).toMatch(/rgba?\(0,\s*0,\s*0,\s*0\)|transparent/);
+    expect(spanStyles?.cursor).toBe('text');
+  });
+
+  test('Text can be selected by clicking and dragging', async ({ page }) => {
+    await page.waitForTimeout(1000);
+
+    // Get position of first text span
+    const spanBounds = await page.evaluate(() => {
+      const span = document.querySelector('.pdfagogo-text-layer span') as HTMLElement;
+      if (!span) return null;
+      const rect = span.getBoundingClientRect();
+      return { x: rect.x, y: rect.y, width: rect.width, height: rect.height };
+    });
+
+    if (spanBounds && spanBounds.width > 0) {
+      // Select some text by dragging
+      await selectTextByDrag(
+        page,
+        spanBounds.x + 5,
+        spanBounds.y + spanBounds.height / 2,
+        spanBounds.x + Math.min(spanBounds.width, 100),
+        spanBounds.y + spanBounds.height / 2
+      );
+
+      const selectedText = await getSelectedText(page);
+      // Should have some text selected (even if just whitespace)
+      expect(selectedText.length).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  test('Text layer is properly positioned over canvas', async ({ page }) => {
+    const positioning = await page.evaluate(() => {
+      const canvas = document.querySelector('.pdfagogo-page-canvas') as HTMLElement;
+      const textLayer = document.querySelector('.pdfagogo-text-layer') as HTMLElement;
+
+      if (!canvas || !textLayer) return null;
+
+      const canvasRect = canvas.getBoundingClientRect();
+      const textLayerRect = textLayer.getBoundingClientRect();
+
+      return {
+        canvasTop: canvasRect.top,
+        canvasLeft: canvasRect.left,
+        canvasWidth: canvasRect.width,
+        canvasHeight: canvasRect.height,
+        textLayerTop: textLayerRect.top,
+        textLayerLeft: textLayerRect.left,
+        textLayerWidth: textLayerRect.width,
+        textLayerHeight: textLayerRect.height,
+      };
+    });
+
+    expect(positioning).not.toBeNull();
+    if (positioning) {
+      // Text layer should be positioned at same location as canvas
+      expect(Math.abs(positioning.textLayerTop - positioning.canvasTop)).toBeLessThan(5);
+      expect(Math.abs(positioning.textLayerLeft - positioning.canvasLeft)).toBeLessThan(5);
+      // Text layer should cover the canvas
+      expect(positioning.textLayerWidth).toBeGreaterThan(0);
+      expect(positioning.textLayerHeight).toBeGreaterThan(0);
+    }
+  });
+
+  test('Text layer has higher z-index than canvas', async ({ page }) => {
+    const zIndexes = await page.evaluate(() => {
+      const canvas = document.querySelector('.pdfagogo-page-canvas') as HTMLElement;
+      const textLayer = document.querySelector('.pdfagogo-text-layer') as HTMLElement;
+
+      if (!canvas || !textLayer) return null;
+
+      const canvasZIndex = parseInt(window.getComputedStyle(canvas).zIndex) || 0;
+      const textLayerZIndex = parseInt(window.getComputedStyle(textLayer).zIndex) || 0;
+
+      return { canvasZIndex, textLayerZIndex };
+    });
+
+    expect(zIndexes).not.toBeNull();
+    if (zIndexes) {
+      expect(zIndexes.textLayerZIndex).toBeGreaterThan(zIndexes.canvasZIndex);
+    }
+  });
+
+  test('Multiple text spans are created for PDF content', async ({ page }) => {
+    await page.waitForTimeout(1000);
+
+    const spanCount = await getTextLayerSpanCount(page);
+    // A typical PDF page should have multiple text elements
+    expect(spanCount).toBeGreaterThan(5);
+  });
+
+  test('Text layer is cleared when page is cleaned up', async ({ page }) => {
+    // Scroll to trigger page cleanup
+    await page.evaluate(() => {
+      const container = document.querySelector('.pdfagogo-scroll-container');
+      if (container) {
+        // Scroll far down to trigger cleanup of first pages
+        container.scrollTop = container.scrollHeight;
+      }
+    });
+
+    // Wait for cleanup to occur
+    await page.waitForTimeout(2000);
+
+    // Scroll back to top
+    await page.evaluate(() => {
+      const container = document.querySelector('.pdfagogo-scroll-container');
+      if (container) {
+        container.scrollTop = 0;
+      }
+    });
+
+    // Wait for re-render
+    await page.waitForTimeout(2000);
+
+    // Text layer should be repopulated
+    const hasContent = await textLayerHasContent(page);
+    expect(hasContent).toBe(true);
+  });
+});
+
+test.describe('PDF-A-go-go Text Selection - Large Document', () => {
+  test('Text layer works on large documents', async ({ page }) => {
+    await page.goto('http://localhost:9000/stress-test-large-pdf.html');
+    await waitForPdfLoad(page);
+    await page.waitForTimeout(2000);
+
+    const hasContent = await textLayerHasContent(page);
+    expect(hasContent).toBe(true);
+  });
+});


### PR DESCRIPTION
Redesign toolbar with modern icons and improved page navigation

<img width="761" height="198" alt="grafik" src="https://github.com/user-attachments/assets/77d08bf8-acfd-429c-8efa-2d1b4f0bf0f0" />

## Summary

- Redesign toolbar with unified layout: page navigation (left), search (center), actions (right)
- Replace custom SVG icons with https://lucide.dev icons (MIT License) for better visual consistency
- New page navigation pattern inspired by https://github.com/embedpdf/embed-pdf-viewer: prev/next chevrons with editable page input showing current page
- Add disabled states for prev/next buttons at document boundaries
- Fix vertical alignment issues across all toolbar elements with\ consistent 28px heights
- Hide number input spinners on page selector
- Use change event instead of keydown for page input (fires on Enter or blur)
- Adds text selection feature

## Changes

- src/assets/js/ui.js - New toolbar structure, Lucide icons, page navigation logic
- src/assets/js/search.js - Lucide chevron icons for search navigation
- src/assets/css/pdf-a-go-go.css - New .pdfagogo-page-nav component, alignment fixes, disabled button states
- README.md - Added Credits section (PDF.js, Lucide, embed-pdf-viewer) Related
- Blog post comparing embed-pdf and PDF-A-go-go: https://www.allaboutken.com/posts/20250905-embedpdf-and-pdf-a-go-go/
- UI inspiration: https://github.com/embedpdf/embed-pdf-viewer