### PR TITLE
fix: switch back to modern PDF.js build

### DIFF
--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -8,7 +8,5 @@ Findings from code audit and architecture review, organized by effort level.
 
 ## Priority 3 -- Larger Opportunities
 
-- **Switch back to PDF.js modern build**: Currently using the legacy build (`pdfjs-dist/legacy/build/`) to support Samsung Internet, which lacks `Uint8Array.toHex()` (requires Chromium 140+). Samsung Internet 29 ships Chromium 136. Revisit once Samsung Internet reaches Chromium 140+ (estimated late 2026). See `pdfLoader.js` imports and `webpack.config.js` worker rule.
-
 - **OffscreenCanvas rendering**: Now universally supported in modern browsers. Could move tile rendering to web workers via `ImageBitmap` transfer for non-blocking rendering.
 - **PDF.js struct tree support**: PDF.js v5.x has improved tagged PDF and accessibility tree features. Worth exposing for better screen reader support on tagged PDFs.

--- a/README.md
+++ b/README.md
@@ -160,12 +160,13 @@ Set options via `data-*` attributes on the container element:
 
 | Browser | Minimum Version |
 | --- | --- |
-| Chrome | 109+ |
-| Firefox | 128+ |
-| Safari | 15.6+ |
-| Edge | 133+ |
-| iOS Safari | 15.6+ |
-| Android Chrome | 135+ |
+| Chrome | 119+ |
+| Firefox | 124+ |
+| Safari | 17.4+ |
+| Edge | 119+ |
+| iOS Safari | 17.4+ |
+| Android Chrome | 119+ |
+| Samsung Internet | 25+ |
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -158,15 +158,15 @@ Set options via `data-*` attributes on the container element:
 <details>
 <summary><strong>Browser support</strong></summary>
 
-| Browser | Minimum Version |
-| --- | --- |
-| Chrome | 119+ |
-| Firefox | 124+ |
-| Safari | 17.4+ |
-| Edge | 119+ |
-| iOS Safari | 17.4+ |
-| Android Chrome | 119+ |
-| Samsung Internet | 25+ |
+| Browser | Minimum Version | Release Date | Limiting API |
+| --- | --- | --- | --- |
+| Chrome | 119+ | Oct 2023 | `Promise.withResolvers()` |
+| Firefox | 124+ | Mar 2024 | `AbortSignal.any()` |
+| Safari | 17.4+ | Mar 2024 | `Promise.withResolvers()`, `AbortSignal.any()` |
+| Edge | 119+ | Nov 2023 | `Promise.withResolvers()` |
+| iOS Safari | 17.4+ | Mar 2024 | `Promise.withResolvers()`, `AbortSignal.any()` |
+| Android Chrome | 119+ | Oct 2023 | `Promise.withResolvers()` |
+| Samsung Internet | 25+ | May 2024 | `Promise.withResolvers()` |
 
 </details>
 

--- a/src/assets/js/pdfLoader.js
+++ b/src/assets/js/pdfLoader.js
@@ -26,8 +26,8 @@
  * @param {number} options.downloadTimeout - Timeout for HTML download handling
  * @returns {Promise<Object>} Resolves with the loaded PDF document.
  */
-import * as pdfjsLib from "pdfjs-dist/legacy/build/pdf.mjs";
-import pdfWorkerUrl from "pdfjs-dist/legacy/build/pdf.worker.min.mjs";
+import * as pdfjsLib from "pdfjs-dist/build/pdf.mjs";
+import pdfWorkerUrl from "pdfjs-dist/build/pdf.worker.min.mjs";
 import { HTMLDownloadHandler } from "./htmlDownloadHandler.js";
 
 /** @type {string|null} Custom worker URL (null = use bundled default) */

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -56,7 +56,7 @@ const base = {
   module: {
     rules: [
       {
-        test: /legacy\/build\/pdf\.worker(\.min)?\.mjs$/,
+        test: /pdf\.worker(\.min)?\.mjs$/,
         type: 'asset/resource',
         generator: {
           filename: 'pdf-a-go-go.dependencies.js'
@@ -94,11 +94,6 @@ const base = {
 
 const prod = Object.assign({}, base, {
   mode: "production",
-  optimization: {
-    // Disable scope hoisting: pdfjs-dist is a pre-built webpack bundle whose
-    // internal module registry variable collides with ours when concatenated.
-    concatenateModules: false,
-  },
 })
 
 const dev = Object.assign({}, base, {


### PR DESCRIPTION
## Summary

- Reverts PDF.js imports from `pdfjs-dist/legacy/build/` to `pdfjs-dist/build/` (modern build)
- Re-enables webpack scope hoisting by removing `concatenateModules: false`
- Updates browser support table to reflect actual API requirements (`Promise.withResolvers()`, `AbortSignal.any()`)
- Removes completed backlog item from IMPROVEMENTS.md

## Context

The legacy build was added in `eb56508` for Samsung Internet compatibility, and scope hoisting was disabled in `66bc810` to work around a `t[n] is not a function` collision caused by the legacy build bundling core-js with its own webpack module registry.

The modern pdfjs-dist v5.4.530 build already polyfills the APIs that motivated the legacy switch (`Uint8Array.toHex()`, `Promise.try()`, `Math.sumPrecise()`). The three unpolyfilled APIs set the browser floor:

| API | Chrome | Firefox | Safari |
|---|---|---|---|
| `Promise.withResolvers()` | 119 | 121 | 17.4 |
| `AbortSignal.any()` | 116 | **124** | 17.4 |
| `structuredClone()` | 98 | 94 | 15.4 |

**Net minimum**: Chrome/Edge 119+, Firefox 124+, Safari/iOS 17.4+, Samsung Internet 25+. All released by May 2024.

## Test plan

- [x] `npm run build` — production build succeeds with scope hoisting active (`+ 11 modules`)
- [x] No core-js polyfills in `dist/pdf-a-go-go.js` (0 matches)
- [x] No `t[n]` collision pattern in bundle
- [x] `npm test` — all 70 Playwright tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)